### PR TITLE
Fix instructions to clone the repo - avoid permissions denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The current installation of Platform 6 relies on [Docker Compose](https://docs.d
 Once Docker is running, clone the Git repository into a new directory dedicated to your local instance.
 
 ```
-git clone git@github.com:amalto/platform6-install.git my-instance
+git clone https://github.com/amalto/platform6-install.git my-instance
 cd my-instance
 ```
 


### PR DESCRIPTION
I was unable to clone the public repo as git is trying to authenticate. I replaced it with the https link.