### PR TITLE
add link to P6 console into readme

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -24,7 +24,7 @@ The network ports we expose from our containers are:
 
 ### Step 1
 
-In your P6 Console account navigate to the _Instances_ menu. Then click the _Add_ button.
+Go to [P6 Console](https://staging.console.sidetrade.io/) and in your P6 Console account navigate to the _Instances_ menu. Then click the _Add_ button.
 
 ![Go to Instances Menu](../_img/go_to_instances_menu.png)
 


### PR DESCRIPTION
I had to ask to know the p6 console URL, I think like this it will be much clear.